### PR TITLE
feat: add Braintree provider support to http-simple-agent-py

### DIFF
--- a/http-simple-agent-py/pyproject.toml
+++ b/http-simple-agent-py/pyproject.toml
@@ -14,7 +14,7 @@ uvicorn = ">=0.30.0"
 openai = "^1.40.0"
 python-dotenv = "^1.0.0"
 httpx = "^0.28.0"
-payments-py = {version = "^1.3.0", extras = ["fastapi"]}
+payments-py = {version = "^1.5.0", extras = ["fastapi"]}
 
 [tool.poetry.scripts]
 agent = "src.agent:main"

--- a/http-simple-agent-py/src/agent.py
+++ b/http-simple-agent-py/src/agent.py
@@ -71,6 +71,8 @@ app.add_middleware(
         "POST /ask": {
             "plan_id": NVM_PLAN_ID,
             "credits": 1,
+            "description": "Send a query to the AI assistant",
+            "mime_type": "application/json",
         },
     },
 )

--- a/http-simple-agent-py/src/client.py
+++ b/http-simple-agent-py/src/client.py
@@ -26,7 +26,7 @@ import httpx
 from payments_py import Payments, PaymentOptions
 from payments_py.x402.fastapi import X402_HEADERS
 from payments_py.x402.resolve_scheme import resolve_scheme
-from payments_py.x402.types import CardDelegationConfig, X402TokenOptions
+from payments_py.x402.types import DelegationConfig, X402TokenOptions
 
 # Configuration
 SERVER_URL = os.getenv("SERVER_URL", "http://localhost:3000")
@@ -120,25 +120,38 @@ def main():
         print("STEP 3: Resolve scheme and generate x402 access token")
         print("=" * 60)
 
-        # Auto-detect scheme from plan metadata (crypto vs fiat)
-        scheme = resolve_scheme(payments, NVM_PLAN_ID)
-        print(f"\nResolved scheme: {scheme}")
+        # Extract scheme and network from server's payment requirements
+        accepts = payment_required.get("accepts", [])
+        accepted = accepts[0] if accepts else {}
+        scheme = accepted.get("scheme", resolve_scheme(payments, NVM_PLAN_ID))
+        network = accepted.get("network")
+        print(f"\nResolved scheme: {scheme}, network: {network}")
 
         # Build token options based on scheme
         token_options = X402TokenOptions(scheme=scheme)
 
         if scheme == "nvm:card-delegation":
             print("\nFiat plan detected - setting up card delegation...")
-            # List payment methods and use the first one
+            # List payment methods and find one matching the server's accepted network
             methods = payments.delegation.list_payment_methods()
             if not methods:
-                print("No payment methods enrolled. Please add a card first.")
+                print("No payment methods enrolled. Please add a card/PayPal at https://nevermined.app")
                 sys.exit(1)
-            pm = methods[0]
-            print(f"Using payment method: {pm.brand} *{pm.last4}")
+
+            # Match payment method provider to server's accepted network
+            pm = None
+            if network:
+                pm = next((m for m in methods if getattr(m, "provider", None) == network), None)
+                if pm:
+                    print(f"Matched payment method for network '{network}': {pm.brand} *{pm.last4}")
+            if not pm:
+                pm = methods[0]
+                print(f"Using payment method: {pm.brand} *{pm.last4} (provider: {getattr(pm, 'provider', 'unknown')})")
+
             token_options = X402TokenOptions(
                 scheme=scheme,
-                delegation_config=CardDelegationConfig(
+                network=network,
+                delegation_config=DelegationConfig(
                     provider_payment_method_id=pm.id,
                     spending_limit_cents=10000,
                     duration_secs=604800,


### PR DESCRIPTION
## Summary

- Bump `payments-py` from `^1.3.0` to `^1.5.0` (adds Braintree provider support)
- Add `description` and `mime_type` to FastAPI x402 middleware route config (new SDK fields)
- Update client to extract scheme/network from server's 402 `accepts` header instead of only calling `resolve_scheme()`
- Network-aware payment method selection: matches enrolled card provider to the server's accepted network (Stripe vs Braintree)
- Rename `CardDelegationConfig` → `DelegationConfig` (SDK rename in v1.5.0)

## Test plan

- [ ] Run `poetry install` and verify `payments-py>=1.5.0` resolves
- [ ] Start agent with a fiat Stripe plan → verify client picks Stripe card
- [ ] Start agent with a fiat Braintree plan → verify client picks Braintree card
- [ ] Start agent with a crypto plan → verify client uses ERC-4337 scheme

🤖 Generated with [Claude Code](https://claude.com/claude-code)