### PR TITLE
fix(http-simple-agent-py): supply delegation_config for crypto plans

### DIFF
--- a/http-simple-agent-py/src/client.py
+++ b/http-simple-agent-py/src/client.py
@@ -160,6 +160,19 @@ def main():
             )
         else:
             print("\nCrypto plan detected - using ERC-4337 scheme")
+            # nvm:erc4337 also requires a delegation_config so the API can
+            # auto-create the ERC-4337 delegation that backs the payment
+            # signature. Same shape as the fiat branch above, but currency
+            # is the on-chain ERC-20 (usdc on Base / Base Sepolia).
+            token_options = X402TokenOptions(
+                scheme=scheme,
+                network=network,
+                delegation_config=DelegationConfig(
+                    spending_limit_cents=10000,
+                    duration_secs=604800,
+                    currency="usdc",
+                ),
+            )
 
         print("\nCalling payments.x402.get_x402_access_token()...")
 


### PR DESCRIPTION
## Summary

Hit while testing nvm-monorepo's off-chain credits epic ([#1274](https://github.com/nevermined-io/nvm-monorepo/issues/1274)) end-to-end against staging. The Python tutorial client was generating x402 access tokens for crypto (`nvm:erc4337`) plans without a `delegation_config`, which the API now requires for ERC-4337 delegations to auto-create the spending-limit policy. The TypeScript tutorial already had this; the Python one was missing the equivalent branch.

## What changed

`http-simple-agent-py/src/client.py` — in the scheme-resolution block, the crypto branch now passes a `DelegationConfig` to `X402TokenOptions`:

```python
token_options = X402TokenOptions(
    scheme=scheme,
    network=network,
    delegation_config=DelegationConfig(
        spending_limit_cents=10000,
        duration_secs=604800,
        currency="usdc",
    ),
)
```

Same shape as the existing `nvm:card-delegation` branch, with `currency="usdc"` instead of `"usd"` (the on-chain ERC-20 on Base/Base Sepolia).

## Why

The fiat (`nvm:card-delegation`) branch already supplied a `delegation_config`. Crypto plans started failing with `Error generating X402 access token` after the API change in [nvm-monorepo#1291](https://github.com/nevermined-io/nvm-monorepo/pull/1291) made `delegation_config` required for `nvm:erc4337` (`BCK.X402.0005` thrown otherwise). This brings the Python client in line.

## Test plan

Verified in staging (sandbox-staging-api) and in production sandbox (`api.sandbox.nevermined.app`):

- [x] Tutorial generates an x402 token for a new crypto plan and completes the full flow (verify → settle → off-chain burn).
- [x] Same flow works against a pre-existing legacy crypto plan that triggers the on-chain backfill (`Backfilled N credit(s) from on-chain` log line on the API side).
- [x] No regression on fiat (card-delegation) flow — that branch was untouched.

## Out of scope

- The Strands tutorial and other Python examples in this repo — none of them call `payments.x402.get_x402_access_token()` for `nvm:erc4337` schemes today; they only need touching when they add a crypto plan path.
- The TypeScript tutorial — already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)