### PR TITLE
feat(langchain-paid-agent-py): Sprint 0 — baseline LangChain tutorial

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Most tutorials require these environment variables in a `.env` file:
 ```bash
 # Nevermined credentials (required)
 NVM_API_KEY=nvm:your-api-key
-NVM_ENVIRONMENT=sandbox          # or 'live', 'staging_sandbox'
+NVM_ENVIRONMENT=sandbox          # or 'live'
 NVM_PLAN_ID=your-plan-id
 NVM_AGENT_ID=your-agent-id       # optional, for agent-specific plans
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,7 @@ This repository contains tutorials and examples demonstrating how to integrate *
 tutorials/
 ├── http-simple-agent-ts/   # Express.js agent with x402 payment middleware (TypeScript)
 ├── http-simple-agent-py/   # FastAPI agent with x402 payment middleware (Python)
+├── langchain-paid-agent-py/# Minimal LangChain @requires_payment + LangGraph agent (Python)
 ├── a2a-examples/           # Agent-to-Agent (A2A) protocol examples
 ├── mcp-examples/           # Model Context Protocol (MCP) examples
 │   ├── weather-mcp/        # TypeScript MCP server (has CLAUDE.md)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,28 @@ Similar to the financial agent, this tutorial demonstrates protecting a medical 
 
 ---
 
-### 4. Weather MCP Server (TypeScript)
+### 4. LangChain Paid Agent (Python)
+
+**Location**: `langchain-paid-agent-py/`
+
+A deliberately minimal LangChain + LangGraph tutorial showing how to gate a single tool with Nevermined payments via the `@requires_payment` decorator. No HTTP layer, no 402 round-trip — the buyer threads an x402 access token through `RunnableConfig.configurable` and the tool verifies + settles in-process.
+
+**Technologies**:
+- Python 3.10+
+- LangChain (`langchain-core`, `langchain-openai`)
+- LangGraph (`create_react_agent`)
+- Nevermined Payments SDK (`payments-py[langchain]`)
+- OpenAI GPT-4o-mini
+
+**What You'll Learn**:
+- Protect a LangChain `@tool` with `@requires_payment`
+- Acquire an x402 access token with `payments.x402.get_x402_access_token(plan_id=...)`
+- Thread the token through `agent.invoke(..., config={"configurable": {"payment_token": ...}})`
+- Read the settlement receipt back from `configurable["payment_settlement"]`
+
+---
+
+### 5. Weather MCP Server (TypeScript)
 
 **Location**: `mcp-examples/weather-mcp/`
 
@@ -116,7 +137,7 @@ A reference implementation of the Model Context Protocol (MCP) with Nevermined p
 
 ---
 
-### 5. Weather MCP Server (Python)
+### 6. Weather MCP Server (Python)
 
 **Location**: `mcp-examples/weather-mcp-py/`
 

--- a/langchain-paid-agent-py/.env.example
+++ b/langchain-paid-agent-py/.env.example
@@ -7,7 +7,12 @@ NVM_API_KEY=nvm:your-api-key
 NVM_ENVIRONMENT=sandbox
 
 # The plan the account has subscribed to and the tool charges against.
+# This tutorial assumes a fiat plan using a card-delegation payment scheme.
 NVM_PLAN_ID=your-plan-id
+
+# Provider of the enrolled payment method to use. Must match the provider
+# the plan was created against (stripe, braintree, …). Defaults to stripe.
+# NVM_PAYMENT_PROVIDER=stripe
 
 # OpenAI key used by the agent's LLM.
 OPENAI_API_KEY=sk-your-openai-key

--- a/langchain-paid-agent-py/.env.example
+++ b/langchain-paid-agent-py/.env.example
@@ -3,7 +3,7 @@
 # the plan and acquires x402 access tokens against it).
 NVM_API_KEY=nvm:your-api-key
 
-# Nevermined environment — sandbox (default), staging_sandbox, or live.
+# Nevermined environment — sandbox (default) or live.
 NVM_ENVIRONMENT=sandbox
 
 # The plan the account has subscribed to and the tool charges against.

--- a/langchain-paid-agent-py/.env.example
+++ b/langchain-paid-agent-py/.env.example
@@ -1,0 +1,21 @@
+# Seller (creator) Nevermined API key — owns the plan and the protected tool.
+NVM_API_KEY=nvm:your-builder-api-key
+
+# Buyer (subscriber) Nevermined API key — has purchased the plan and acquires
+# x402 access tokens against it.
+NVM_SUBSCRIBER_API_KEY=nvm:your-subscriber-api-key
+
+# Nevermined environment — sandbox (default), staging_sandbox, or live.
+NVM_ENVIRONMENT=sandbox
+
+# The plan the buyer has subscribed to and the tool charges against.
+NVM_PLAN_ID=your-plan-id
+
+# OpenAI key used by the agent's LLM.
+OPENAI_API_KEY=sk-your-openai-key
+
+# Optional model override (defaults to gpt-4o-mini).
+# MODEL_ID=gpt-4o-mini
+
+# Optional query override.
+# QUERY=What's the market insight on electric vehicles?

--- a/langchain-paid-agent-py/.env.example
+++ b/langchain-paid-agent-py/.env.example
@@ -1,14 +1,12 @@
-# Seller (creator) Nevermined API key — owns the plan and the protected tool.
-NVM_API_KEY=nvm:your-builder-api-key
-
-# Buyer (subscriber) Nevermined API key — has purchased the plan and acquires
-# x402 access tokens against it.
-NVM_SUBSCRIBER_API_KEY=nvm:your-subscriber-api-key
+# Your Nevermined API key. The same account acts as both the seller
+# (owns the plan and the protected tool) and the buyer (subscribed to
+# the plan and acquires x402 access tokens against it).
+NVM_API_KEY=nvm:your-api-key
 
 # Nevermined environment — sandbox (default), staging_sandbox, or live.
 NVM_ENVIRONMENT=sandbox
 
-# The plan the buyer has subscribed to and the tool charges against.
+# The plan the account has subscribed to and the tool charges against.
 NVM_PLAN_ID=your-plan-id
 
 # OpenAI key used by the agent's LLM.

--- a/langchain-paid-agent-py/.env.example
+++ b/langchain-paid-agent-py/.env.example
@@ -6,13 +6,11 @@ NVM_API_KEY=nvm:your-api-key
 # Nevermined environment — sandbox (default) or live.
 NVM_ENVIRONMENT=sandbox
 
-# The plan the account has subscribed to and the tool charges against.
+# The plan the SELLER's tool charges against. The buyer never reads this —
+# it discovers the plan id (and scheme + provider) from the protocol error
+# the first time it calls the agent without a token.
 # This tutorial assumes a fiat plan using a card-delegation payment scheme.
 NVM_PLAN_ID=your-plan-id
-
-# Provider of the enrolled payment method to use. Must match the provider
-# the plan was created against (stripe, braintree, …). Defaults to stripe.
-# NVM_PAYMENT_PROVIDER=stripe
 
 # OpenAI key used by the agent's LLM.
 OPENAI_API_KEY=sk-your-openai-key

--- a/langchain-paid-agent-py/.gitignore
+++ b/langchain-paid-agent-py/.gitignore
@@ -1,0 +1,9 @@
+.env
+.venv/
+__pycache__/
+*.pyc
+dist/
+build/
+*.egg-info/
+.poetry/
+poetry.lock

--- a/langchain-paid-agent-py/README.md
+++ b/langchain-paid-agent-py/README.md
@@ -7,6 +7,8 @@ A minimal LangChain / LangGraph agent with a single tool gated by [Nevermined](h
 
 Everything else (agent prompt, tool body, model choice) is deliberately trivial so the payment flow is the only signal.
 
+> **Note — one Nevermined account for both roles.** In production the seller (plan owner) and the buyer (plan subscriber) are typically separate Nevermined accounts with separate API keys. This tutorial uses a **single** account for both roles so the demo only requires one Nevermined signup. Your account creates a plan, subscribes to it, then acts as both the protected-tool host and the x402 token holder.
+
 For the full, production-ready reference see the published guide: **[Nevermined LangChain integration](https://nevermined.ai/docs/integrate/add-to-your-agent/langchain)**.
 
 ## Payment flow
@@ -45,9 +47,11 @@ Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../htt
 ### 1. Prerequisites
 
 - Python 3.10+
-- A Nevermined builder account at [nevermined.app](https://nevermined.app) with one **plan** created. The plan is what the buyer subscribes to and the tool charges against.
-- A subscriber account that has **purchased the plan** (one click on the plan page).
-- Both accounts have an API key (`Settings → API Keys`). The builder key goes in `NVM_API_KEY`, the subscriber key in `NVM_SUBSCRIBER_API_KEY`.
+- A Nevermined account at [nevermined.app](https://nevermined.app). The **same** account plays both roles in this demo:
+  - As the seller, it owns the plan and the protected tool.
+  - As the buyer, it has subscribed to the plan and acquires x402 access tokens against it.
+- An API key for the account (`Settings → API Keys`) — goes into `NVM_API_KEY`.
+- A **plan** created and subscribed (one click each on the plan page) — its id goes into `NVM_PLAN_ID`.
 - An OpenAI API key for the agent's LLM.
 
 > Need the click-by-click for the plan setup? Follow the [5-minute setup](https://nevermined.ai/docs/integrate/quickstart/5-minute-setup).
@@ -64,7 +68,7 @@ poetry install
 cp .env.example .env
 ```
 
-Fill in `NVM_API_KEY`, `NVM_SUBSCRIBER_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`.
+Fill in `NVM_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`.
 
 ### 4. Run
 
@@ -101,12 +105,12 @@ from langchain_core.tools import tool
 from payments_py import Payments, PaymentOptions
 from payments_py.x402.langchain import requires_payment
 
-seller_payments = Payments.get_instance(
+payments = Payments.get_instance(
     PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
 )
 
 @tool
-@requires_payment(payments=seller_payments, plan_id=NVM_PLAN_ID, credits=1)
+@requires_payment(payments=payments, plan_id=NVM_PLAN_ID, credits=1)
 def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
     """Return a short market insight for the requested topic. Costs 1 credit."""
     return f"Market insight for '{topic}': ..."
@@ -123,11 +127,13 @@ Two requirements for the tool function:
 from payments_py import Payments, PaymentOptions
 from .agent import create_agent
 
-buyer_payments = Payments.get_instance(
-    PaymentOptions(nvm_api_key=NVM_SUBSCRIBER_API_KEY, environment=NVM_ENVIRONMENT)
+# Same Nevermined account as the seller in this demo; the account has
+# subscribed to its own plan to acquire x402 access tokens.
+payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
 )
 
-token = buyer_payments.x402.get_x402_access_token(NVM_PLAN_ID)["accessToken"]
+token = payments.x402.get_x402_access_token(NVM_PLAN_ID)["accessToken"]
 
 agent = create_agent()
 configurable = {"payment_token": token}

--- a/langchain-paid-agent-py/README.md
+++ b/langchain-paid-agent-py/README.md
@@ -1,0 +1,162 @@
+# LangChain Paid Agent (Python)
+
+A minimal LangChain / LangGraph agent with a single tool gated by [Nevermined](https://nevermined.ai) payments. The tutorial exists to show two things and nothing else:
+
+1. **How a seller protects a LangChain tool** — wrap it with `@requires_payment`.
+2. **How a buyer pays for an invocation** — acquire an x402 access token and thread it through `RunnableConfig.configurable.payment_token`.
+
+Everything else (agent prompt, tool body, model choice) is deliberately trivial so the payment flow is the only signal.
+
+For the full, production-ready reference see the published guide: **[Nevermined LangChain integration](https://nevermined.ai/docs/integrate/add-to-your-agent/langchain)**.
+
+## Payment flow
+
+Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../http-simple-agent-py/)), the LangChain tool decorator runs in-process: there is no `402` round-trip and no retry. The buyer acquires the token once, then threads it through the agent's `RunnableConfig`. The tool verifies and settles inside the agent's tool call.
+
+```text
+┌─────────┐                                                   ┌────────────────┐
+│  Buyer  │                                                   │  Seller agent  │
+│ script  │                                                   │  (in-process)  │
+└────┬────┘                                                   └────────┬───────┘
+     │                                                                 │
+     │  1. get_x402_access_token(plan_id)                              │
+     │      via payments-py (buyer SDK)                                │
+     │                                                                 │
+     │  2. agent.invoke({"messages": [...]}, config={                  │
+     │        "configurable": {"payment_token": token}})               │
+     │ ───────────────────────────────────────────────────────────────>│
+     │                                                                 │
+     │                                          ┌──────────────────────┘
+     │                                          │  ReAct loop:
+     │                                          │    LLM picks the tool
+     │                                          │    @requires_payment:
+     │                                          │      a) verify token
+     │                                          │      b) execute tool body
+     │                                          │      c) settle (burn credits)
+     │                                          └──────────────────────┐
+     │                                                                 │
+     │  3. answer + settlement receipt                                 │
+     │     (config.configurable.payment_settlement)                    │
+     │ <───────────────────────────────────────────────────────────────│
+```
+
+## Quick start
+
+### 1. Prerequisites
+
+- Python 3.10+
+- A Nevermined builder account at [nevermined.app](https://nevermined.app) with one **plan** created. The plan is what the buyer subscribes to and the tool charges against.
+- A subscriber account that has **purchased the plan** (one click on the plan page).
+- Both accounts have an API key (`Settings → API Keys`). The builder key goes in `NVM_API_KEY`, the subscriber key in `NVM_SUBSCRIBER_API_KEY`.
+- An OpenAI API key for the agent's LLM.
+
+> Need the click-by-click for the plan setup? Follow the [5-minute setup](https://nevermined.ai/docs/integrate/quickstart/5-minute-setup).
+
+### 2. Install
+
+```bash
+poetry install
+```
+
+### 3. Configure
+
+```bash
+cp .env.example .env
+```
+
+Fill in `NVM_API_KEY`, `NVM_SUBSCRIBER_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`.
+
+### 4. Run
+
+```bash
+poetry run buyer
+```
+
+Expected output (truncated):
+
+```text
+[1/4] Acquiring x402 access token for plan plan_abc...
+      token = eyJhbGciOi...  (truncated)
+
+[2/4] Building the LangGraph agent...
+
+[3/4] Invoking the agent with query: 'What's the market insight on electric vehicles?'
+
+      Agent answer: Demand is up 12% quarter-on-quarter ...
+
+[4/4] Settlement receipt (from configurable.payment_settlement):
+      credits_redeemed: 1
+      remaining_balance: 49
+      transaction: 0x...
+      network: base-sepolia
+      payer: 0x...
+```
+
+## Code walkthrough
+
+### Seller: protect the tool (`src/agent.py`)
+
+```python
+from langchain_core.tools import tool
+from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import requires_payment
+
+seller_payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
+)
+
+@tool
+@requires_payment(payments=seller_payments, plan_id=NVM_PLAN_ID, credits=1)
+def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
+    """Return a short market insight for the requested topic. Costs 1 credit."""
+    return f"Market insight for '{topic}': ..."
+```
+
+Two requirements for the tool function:
+
+- Decorator order is `@tool` *outside* `@requires_payment` *inside*.
+- The function signature **must** include `config: RunnableConfig` — that is how the decorator reads the payment token at call time.
+
+### Buyer: acquire a token and invoke (`src/buyer.py`)
+
+```python
+from payments_py import Payments, PaymentOptions
+from .agent import create_agent
+
+buyer_payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key=NVM_SUBSCRIBER_API_KEY, environment=NVM_ENVIRONMENT)
+)
+
+token = buyer_payments.x402.get_x402_access_token(NVM_PLAN_ID)["accessToken"]
+
+agent = create_agent()
+configurable = {"payment_token": token}
+result = agent.invoke(
+    {"messages": [("human", "What's the market insight on electric vehicles?")]},
+    config={"configurable": configurable},
+)
+
+settlement = configurable["payment_settlement"]  # populated after settlement
+```
+
+The same `configurable` dict that carried the token *into* the agent receives the settlement receipt on the way *out* — that is how the buyer recovers `credits_redeemed`, `remaining_balance`, and the on-chain `transaction`.
+
+## File layout
+
+```text
+langchain-paid-agent-py/
+├── src/
+│   ├── __init__.py
+│   ├── agent.py     # Paid tool + LangGraph agent factory
+│   └── buyer.py     # Token acquisition + agent invocation + receipt print
+├── pyproject.toml
+├── .env.example
+├── .gitignore
+└── README.md
+```
+
+## Learn more
+
+- [Nevermined LangChain integration guide](https://nevermined.ai/docs/integrate/add-to-your-agent/langchain) — full reference with both this decorator pattern and the HTTP middleware pattern.
+- [Nevermined Payments SDK (Python)](https://github.com/nevermined-io/payments-py)
+- [x402 protocol](https://github.com/coinbase/x402)

--- a/langchain-paid-agent-py/README.md
+++ b/langchain-paid-agent-py/README.md
@@ -136,9 +136,9 @@ Two requirements for the tool function:
 
 ```python
 from payments_py import Payments, PaymentOptions
-from payments_py.x402.langchain import PaymentRequiredError
+from payments_py.x402.langchain import PaymentRequiredError, last_settlement
 from payments_py.x402.types import DelegationConfig, X402TokenOptions
-from .agent import LAST_SETTLEMENT, create_agent
+from .agent import create_agent
 
 payments = Payments.get_instance(
     PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
@@ -155,8 +155,9 @@ except PaymentRequiredError as err:
     # accept.plan_id  → "<plan id>"
 
 # 2. Pick an enrolled payment method whose provider matches accept.network.
-methods = payments.delegation.list_payment_methods()
-pm = next(m for m in methods if m.provider == accept.network)
+#    Extracted into pick_payment_method() in the actual source.
+pm = next(m for m in payments.delegation.list_payment_methods()
+          if m.provider == accept.network)
 
 # 3. Acquire a token against the discovered plan.
 token = payments.x402.get_x402_access_token(
@@ -165,28 +166,30 @@ token = payments.x402.get_x402_access_token(
         scheme=accept.scheme,
         delegation_config=DelegationConfig(
             provider_payment_method_id=pm.id,
-            spending_limit_cents=10000,
-            duration_secs=604800,
+            spending_limit_cents=10000,  # $100 cap per delegation
+            duration_secs=3600,          # 1 hour TTL
             currency="usd",
         ),
     ),
 )["accessToken"]
 
-# 4. Retry with the token.
+# 4. Retry with the token and read the settlement.
 result = agent.invoke(
     {"messages": [("human", "...")]},
     config={"configurable": {"payment_token": token}},
 )
-settlement = LAST_SETTLEMENT["value"]
+settlement = last_settlement()
 ```
 
 ### Why does the agent raise instead of swallowing the error?
 
-By default LangGraph's `ToolNode` catches tool exceptions and surfaces them to the LLM as `ToolMessage` content (`handle_tool_errors=True`). That stringifies the exception and **loses** the `X402PaymentRequired` payload. `src/agent.py` therefore builds the agent with `ToolNode([get_market_insight], handle_tool_errors=False)` so `PaymentRequiredError` propagates all the way up to `agent.invoke()`'s caller with its payload intact.
+By default LangGraph's `ToolNode` catches tool exceptions and surfaces them to the LLM as `ToolMessage` content (`handle_tool_errors=True`). That stringifies the exception and **loses** the `X402PaymentRequired` payload. The SDK ships `create_paid_react_agent` (from `payments_py.x402.langchain`) — a thin wrapper over `langgraph.prebuilt.create_react_agent` that constructs the underlying `ToolNode` with `handle_tool_errors=False` so `PaymentRequiredError` propagates all the way up to `agent.invoke()`'s caller with its payload intact.
 
-### Why `LAST_SETTLEMENT` and not `configurable["payment_settlement"]`?
+### Why `last_settlement()` and not `configurable["payment_settlement"]`?
 
-The decorator writes the settlement receipt to `config["configurable"]["payment_settlement"]`. **LangGraph copies `configurable` into a new dict per node**, so the receipt is set on the *node's copy* of `configurable`, not on the dict the buyer passed in. The seller-side `agent.py` therefore wraps the protected tool with a tiny `_capture_settlement` decorator (placed **outside** `@requires_payment` so it runs after settle) that reads the receipt off the inner `configurable` and stashes it in module-level `LAST_SETTLEMENT` — a place the buyer's outer scope can see.
+The decorator writes the settlement receipt to `config["configurable"]["payment_settlement"]`. **LangGraph copies `configurable` into a new dict per node**, so the receipt is set on the *node's copy* of `configurable`, not on the dict the buyer passed in. ContextVars don't help either — LangGraph runs tools in worker contexts that don't propagate `set()` calls back. `payments_py.x402.langchain.last_settlement()` reads from a module-level slot the decorator updates on every settle, so the buyer can read the receipt from the outer scope.
+
+The slot is process-global — in multi-tenant servers (concurrent settlements), it reflects whichever invocation settled most recently. For multi-tenant scenarios, surface settlement via a callback or observability layer instead.
 
 ### Why does the receipt say `credits_redeemed: 5` when the decorator says `credits=1`?
 

--- a/langchain-paid-agent-py/README.md
+++ b/langchain-paid-agent-py/README.md
@@ -51,7 +51,8 @@ Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../htt
   - As the seller, it owns the plan and the protected tool.
   - As the buyer, it has subscribed to the plan and acquires x402 access tokens against it.
 - An API key for the account (`Settings → API Keys`) — goes into `NVM_API_KEY`.
-- A **plan** created and subscribed (one click each on the plan page) — its id goes into `NVM_PLAN_ID`.
+- A **fiat plan** (card-delegation scheme), created and subscribed, with at least one charge remaining — its id goes into `NVM_PLAN_ID`.
+- A **payment method enrolled** that matches the plan's provider (Stripe by default; set `NVM_PAYMENT_PROVIDER` if your plan uses a different provider).
 - An OpenAI API key for the agent's LLM.
 
 > Need the click-by-click for the plan setup? Follow the [5-minute setup](https://nevermined.ai/docs/integrate/quickstart/5-minute-setup).
@@ -68,7 +69,7 @@ poetry install
 cp .env.example .env
 ```
 
-Fill in `NVM_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`.
+Fill in `NVM_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`. Optionally set `NVM_PAYMENT_PROVIDER` (defaults to `stripe`).
 
 ### 4. Run
 
@@ -125,27 +126,48 @@ Two requirements for the tool function:
 
 ```python
 from payments_py import Payments, PaymentOptions
-from .agent import create_agent
+from payments_py.x402.types import DelegationConfig, X402TokenOptions
+from .agent import LAST_SETTLEMENT, create_agent
 
-# Same Nevermined account as the seller in this demo; the account has
-# subscribed to its own plan to acquire x402 access tokens.
 payments = Payments.get_instance(
     PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
 )
 
-token = payments.x402.get_x402_access_token(NVM_PLAN_ID)["accessToken"]
+# Pick a payment method that matches the plan's provider (default: stripe).
+methods = payments.delegation.list_payment_methods()
+pm = next(m for m in methods if m.provider == "stripe")
+
+# For card-delegation plans the SDK needs delegation_config so the API can
+# auto-create the Stripe delegation that backs the payment signature.
+token = payments.x402.get_x402_access_token(
+    NVM_PLAN_ID,
+    token_options=X402TokenOptions(
+        scheme="nvm:card-delegation",
+        delegation_config=DelegationConfig(
+            provider_payment_method_id=pm.id,
+            spending_limit_cents=10000,  # $100 cap per delegation
+            duration_secs=604800,        # 1 week TTL
+            currency="usd",
+        ),
+    ),
+)["accessToken"]
 
 agent = create_agent()
-configurable = {"payment_token": token}
 result = agent.invoke(
     {"messages": [("human", "What's the market insight on electric vehicles?")]},
-    config={"configurable": configurable},
+    config={"configurable": {"payment_token": token}},
 )
 
-settlement = configurable["payment_settlement"]  # populated after settlement
+settlement = LAST_SETTLEMENT["value"]
 ```
 
-The same `configurable` dict that carried the token *into* the agent receives the settlement receipt on the way *out* — that is how the buyer recovers `credits_redeemed`, `remaining_balance`, and the on-chain `transaction`.
+### Why `LAST_SETTLEMENT` and not `configurable["payment_settlement"]`?
+
+The decorator writes the settlement receipt to `config["configurable"]["payment_settlement"]`. **LangGraph copies `configurable` into a new dict per node**, so the receipt is set on the *node's copy* of `configurable`, not on the dict the buyer passed in. The seller-side `agent.py` therefore wraps the protected tool with a tiny `_capture_settlement` decorator (placed **outside** `@requires_payment` so it runs after settle) that reads the receipt off the inner `configurable` and stashes it in module-level `LAST_SETTLEMENT` — a place the buyer's outer scope can see.
+
+### Why does the receipt say `credits_redeemed: 5` when the decorator says `credits=1`?
+
+For **fixed plans** (the kind this tutorial recommends), the server-side `plan.credits.maxAmount` always wins — the client-side `credits=N` is overridden. The decorator's `credits` parameter is effectively a max-cap that only constrains **range plans** (where `minAmount < maxAmount` and the caller picks the amount within that band). For fixed plans, leaving `credits` at the default `1` is fine; the actual redemption is whatever the plan was configured with.
 
 ## File layout
 

--- a/langchain-paid-agent-py/README.md
+++ b/langchain-paid-agent-py/README.md
@@ -13,7 +13,7 @@ For the full, production-ready reference see the published guide: **[Nevermined 
 
 ## Payment flow
 
-Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../http-simple-agent-py/)), the LangChain tool decorator runs in-process: there is no `402` round-trip and no retry. The buyer acquires the token once, then threads it through the agent's `RunnableConfig`. The tool verifies and settles inside the agent's tool call.
+This tutorial mirrors the x402 HTTP discovery pattern from [`http-simple-agent-py`](../http-simple-agent-py/) but in-process: the buyer first invokes the agent **without** a payment token, the protected tool raises `PaymentRequiredError` carrying the full x402 `accepts` block (scheme, network, plan id), and the buyer uses that to acquire a token before retrying. No plan id, no provider name, no scheme has to be configured on the buyer up front.
 
 ```text
 ┌─────────┐                                                   ┌────────────────┐
@@ -21,10 +21,21 @@ Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../htt
 │ script  │                                                   │  (in-process)  │
 └────┬────┘                                                   └────────┬───────┘
      │                                                                 │
-     │  1. get_x402_access_token(plan_id)                              │
-     │      via payments-py (buyer SDK)                                │
+     │  1. agent.invoke({"messages": [...]},                           │
+     │       config={"configurable": {}})       (no payment_token)     │
+     │ ───────────────────────────────────────────────────────────────>│
      │                                                                 │
-     │  2. agent.invoke({"messages": [...]}, config={                  │
+     │  2. PaymentRequiredError raised                                 │
+     │     .payment_required.accepts[0] →                              │
+     │       scheme, network, plan_id                                  │
+     │ <───────────────────────────────────────────────────────────────│
+     │                                                                 │
+     │  3. Pick an enrolled payment method whose provider              │
+     │     matches accept.network                                      │
+     │                                                                 │
+     │  4. get_x402_access_token(plan_id, token_options=...)           │
+     │                                                                 │
+     │  5. agent.invoke({"messages": [...]}, config={                  │
      │        "configurable": {"payment_token": token}})               │
      │ ───────────────────────────────────────────────────────────────>│
      │                                                                 │
@@ -37,8 +48,7 @@ Unlike the x402 HTTP middleware pattern (used in [`http-simple-agent-py`](../htt
      │                                          │      c) settle (burn credits)
      │                                          └──────────────────────┐
      │                                                                 │
-     │  3. answer + settlement receipt                                 │
-     │     (config.configurable.payment_settlement)                    │
+     │  6. answer + settlement receipt                                 │
      │ <───────────────────────────────────────────────────────────────│
 ```
 
@@ -69,7 +79,7 @@ poetry install
 cp .env.example .env
 ```
 
-Fill in `NVM_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`. Optionally set `NVM_PAYMENT_PROVIDER` (defaults to `stripe`).
+Fill in `NVM_API_KEY`, `NVM_PLAN_ID`, and `OPENAI_API_KEY`. The buyer learns the payment provider from the protocol error — no need to hard-code it.
 
 ### 4. Run
 
@@ -122,44 +132,57 @@ Two requirements for the tool function:
 - Decorator order is `@tool` *outside* `@requires_payment` *inside*.
 - The function signature **must** include `config: RunnableConfig` — that is how the decorator reads the payment token at call time.
 
-### Buyer: acquire a token and invoke (`src/buyer.py`)
+### Buyer: discover, pay, retry (`src/buyer.py`)
 
 ```python
 from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import PaymentRequiredError
 from payments_py.x402.types import DelegationConfig, X402TokenOptions
 from .agent import LAST_SETTLEMENT, create_agent
 
 payments = Payments.get_instance(
     PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
 )
+agent = create_agent()
 
-# Pick a payment method that matches the plan's provider (default: stripe).
+# 1. Probe — invoke without a payment_token to provoke the protocol error.
+try:
+    agent.invoke({"messages": [("human", "...")]}, config={"configurable": {}})
+except PaymentRequiredError as err:
+    accept = err.payment_required.accepts[0]
+    # accept.scheme   → "nvm:card-delegation"
+    # accept.network  → "stripe"
+    # accept.plan_id  → "<plan id>"
+
+# 2. Pick an enrolled payment method whose provider matches accept.network.
 methods = payments.delegation.list_payment_methods()
-pm = next(m for m in methods if m.provider == "stripe")
+pm = next(m for m in methods if m.provider == accept.network)
 
-# For card-delegation plans the SDK needs delegation_config so the API can
-# auto-create the Stripe delegation that backs the payment signature.
+# 3. Acquire a token against the discovered plan.
 token = payments.x402.get_x402_access_token(
-    NVM_PLAN_ID,
+    accept.plan_id,
     token_options=X402TokenOptions(
-        scheme="nvm:card-delegation",
+        scheme=accept.scheme,
         delegation_config=DelegationConfig(
             provider_payment_method_id=pm.id,
-            spending_limit_cents=10000,  # $100 cap per delegation
-            duration_secs=604800,        # 1 week TTL
+            spending_limit_cents=10000,
+            duration_secs=604800,
             currency="usd",
         ),
     ),
 )["accessToken"]
 
-agent = create_agent()
+# 4. Retry with the token.
 result = agent.invoke(
-    {"messages": [("human", "What's the market insight on electric vehicles?")]},
+    {"messages": [("human", "...")]},
     config={"configurable": {"payment_token": token}},
 )
-
 settlement = LAST_SETTLEMENT["value"]
 ```
+
+### Why does the agent raise instead of swallowing the error?
+
+By default LangGraph's `ToolNode` catches tool exceptions and surfaces them to the LLM as `ToolMessage` content (`handle_tool_errors=True`). That stringifies the exception and **loses** the `X402PaymentRequired` payload. `src/agent.py` therefore builds the agent with `ToolNode([get_market_insight], handle_tool_errors=False)` so `PaymentRequiredError` propagates all the way up to `agent.invoke()`'s caller with its payload intact.
 
 ### Why `LAST_SETTLEMENT` and not `configurable["payment_settlement"]`?
 

--- a/langchain-paid-agent-py/pyproject.toml
+++ b/langchain-paid-agent-py/pyproject.toml
@@ -1,0 +1,23 @@
+[tool.poetry]
+name = "langchain-paid-agent-py"
+version = "1.0.0"
+description = "Minimal LangChain agent with a Nevermined-protected tool"
+authors = ["Nevermined <tech@nevermined.io>"]
+license = "MIT"
+readme = "README.md"
+packages = [{include = "src"}]
+
+[tool.poetry.dependencies]
+python = "^3.10"
+python-dotenv = "^1.0.0"
+langchain-core = "^0.3.0"
+langchain-openai = "^0.3.0"
+langgraph = "^0.6.0"
+payments-py = {version = "^1.5.0", extras = ["langchain"]}
+
+[tool.poetry.scripts]
+buyer = "src.buyer:main"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/langchain-paid-agent-py/pyproject.toml
+++ b/langchain-paid-agent-py/pyproject.toml
@@ -13,7 +13,7 @@ python-dotenv = "^1.0.0"
 langchain-core = "^0.3.0"
 langchain-openai = "^0.3.0"
 langgraph = "^0.6.0"
-payments-py = {version = "^1.5.0", extras = ["langchain"]}
+payments-py = {version = "^1.7.0", extras = ["langchain"]}
 
 [tool.poetry.scripts]
 buyer = "src.buyer:main"

--- a/langchain-paid-agent-py/src/agent.py
+++ b/langchain-paid-agent-py/src/agent.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
+from langgraph.prebuilt import ToolNode, create_react_agent
 
 from payments_py import Payments, PaymentOptions
 from payments_py.x402.langchain import requires_payment
@@ -74,11 +74,23 @@ def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
 
 
 def create_agent():
-    """Build a one-tool LangGraph ReAct agent."""
+    """Build a one-tool LangGraph ReAct agent.
+
+    The tool is wrapped in a ToolNode with ``handle_tool_errors=False`` so the
+    ``PaymentRequiredError`` raised by ``@requires_payment`` (when no token is
+    threaded through ``RunnableConfig.configurable``) propagates up to the
+    caller intact, with the full ``X402PaymentRequired`` payload on it. That
+    is how the buyer discovers what to pay for without knowing the plan id,
+    scheme, or provider up front.
+
+    Default ``ToolNode`` behaviour would catch the exception and surface it
+    as a ``ToolMessage`` to the LLM, losing the payload.
+    """
     model = ChatOpenAI(model=os.getenv("MODEL_ID", "gpt-4o-mini"), temperature=0)
     prompt = (
         "You are a market data assistant. When the user asks about a topic, "
         "call the get_market_insight tool to fetch a short insight, then "
         "reply with what you found."
     )
-    return create_react_agent(model, [get_market_insight], prompt=prompt)
+    tool_node = ToolNode([get_market_insight], handle_tool_errors=False)
+    return create_react_agent(model, tool_node, prompt=prompt)

--- a/langchain-paid-agent-py/src/agent.py
+++ b/langchain-paid-agent-py/src/agent.py
@@ -7,17 +7,15 @@ Wrapping it with ``@requires_payment`` makes the function gated on an x402
 access token threaded through ``RunnableConfig.configurable.payment_token``.
 """
 
-import functools
 import os
 
 from dotenv import load_dotenv
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import ToolNode, create_react_agent
 
 from payments_py import Payments, PaymentOptions
-from payments_py.x402.langchain import requires_payment
+from payments_py.x402.langchain import create_paid_react_agent, requires_payment
 
 load_dotenv()
 
@@ -30,34 +28,7 @@ payments = Payments.get_instance(
 )
 
 
-# Holder for the most recent settlement receipt so the buyer can read it
-# after agent.invoke() returns. LangGraph copies RunnableConfig.configurable
-# per node, so the SDK's in-place mutation lives only inside the tool node;
-# this wrapper hoists the receipt back to module scope.
-LAST_SETTLEMENT = {"value": None}
-
-
-def _capture_settlement(func):
-    """Read payment_settlement after @requires_payment has settled.
-
-    Must sit OUTSIDE @requires_payment so it runs after the settle phase.
-    """
-
-    @functools.wraps(func)
-    def wrapper(*args, **kwargs):
-        result = func(*args, **kwargs)
-        config = kwargs.get("config")
-        if isinstance(config, dict):
-            settlement = config.get("configurable", {}).get("payment_settlement")
-            if settlement is not None:
-                LAST_SETTLEMENT["value"] = settlement
-        return result
-
-    return wrapper
-
-
 @tool
-@_capture_settlement
 @requires_payment(payments=payments, plan_id=NVM_PLAN_ID, credits=1)
 def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
     """Return a short market insight for the requested topic.
@@ -74,23 +45,11 @@ def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
 
 
 def create_agent():
-    """Build a one-tool LangGraph ReAct agent.
-
-    The tool is wrapped in a ToolNode with ``handle_tool_errors=False`` so the
-    ``PaymentRequiredError`` raised by ``@requires_payment`` (when no token is
-    threaded through ``RunnableConfig.configurable``) propagates up to the
-    caller intact, with the full ``X402PaymentRequired`` payload on it. That
-    is how the buyer discovers what to pay for without knowing the plan id,
-    scheme, or provider up front.
-
-    Default ``ToolNode`` behaviour would catch the exception and surface it
-    as a ``ToolMessage`` to the LLM, losing the payload.
-    """
+    """Build a one-tool LangGraph ReAct agent that propagates PaymentRequiredError."""
     model = ChatOpenAI(model=os.getenv("MODEL_ID", "gpt-4o-mini"), temperature=0)
     prompt = (
         "You are a market data assistant. When the user asks about a topic, "
         "call the get_market_insight tool to fetch a short insight, then "
         "reply with what you found."
     )
-    tool_node = ToolNode([get_market_insight], handle_tool_errors=False)
-    return create_react_agent(model, tool_node, prompt=prompt)
+    return create_paid_react_agent(model, [get_market_insight], prompt=prompt)

--- a/langchain-paid-agent-py/src/agent.py
+++ b/langchain-paid-agent-py/src/agent.py
@@ -24,13 +24,13 @@ NVM_API_KEY = os.environ["NVM_API_KEY"]
 NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
 NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
 
-seller_payments = Payments.get_instance(
+payments = Payments.get_instance(
     PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
 )
 
 
 @tool
-@requires_payment(payments=seller_payments, plan_id=NVM_PLAN_ID, credits=1)
+@requires_payment(payments=payments, plan_id=NVM_PLAN_ID, credits=1)
 def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
     """Return a short market insight for the requested topic.
 

--- a/langchain-paid-agent-py/src/agent.py
+++ b/langchain-paid-agent-py/src/agent.py
@@ -1,0 +1,56 @@
+"""
+Seller-side: one Nevermined-protected LangChain tool plus a minimal
+LangGraph ReAct agent that uses it.
+
+The tool is the only thing in this file that touches the Nevermined SDK.
+Wrapping it with ``@requires_payment`` makes the function gated on an x402
+access token threaded through ``RunnableConfig.configurable.payment_token``.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import tool
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
+
+from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import requires_payment
+
+load_dotenv()
+
+NVM_API_KEY = os.environ["NVM_API_KEY"]
+NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
+NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
+
+seller_payments = Payments.get_instance(
+    PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
+)
+
+
+@tool
+@requires_payment(payments=seller_payments, plan_id=NVM_PLAN_ID, credits=1)
+def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
+    """Return a short market insight for the requested topic.
+
+    Costs 1 Nevermined credit per call.
+
+    Args:
+        topic: The topic the user wants an insight about.
+    """
+    return (
+        f"Market insight for '{topic}': demand is up 12% quarter-on-quarter "
+        f"and three new entrants joined the segment last month."
+    )
+
+
+def create_agent():
+    """Build a one-tool LangGraph ReAct agent."""
+    model = ChatOpenAI(model=os.getenv("MODEL_ID", "gpt-4o-mini"), temperature=0)
+    prompt = (
+        "You are a market data assistant. When the user asks about a topic, "
+        "call the get_market_insight tool to fetch a short insight, then "
+        "reply with what you found."
+    )
+    return create_react_agent(model, [get_market_insight], prompt=prompt)

--- a/langchain-paid-agent-py/src/agent.py
+++ b/langchain-paid-agent-py/src/agent.py
@@ -7,6 +7,7 @@ Wrapping it with ``@requires_payment`` makes the function gated on an x402
 access token threaded through ``RunnableConfig.configurable.payment_token``.
 """
 
+import functools
 import os
 
 from dotenv import load_dotenv
@@ -29,7 +30,34 @@ payments = Payments.get_instance(
 )
 
 
+# Holder for the most recent settlement receipt so the buyer can read it
+# after agent.invoke() returns. LangGraph copies RunnableConfig.configurable
+# per node, so the SDK's in-place mutation lives only inside the tool node;
+# this wrapper hoists the receipt back to module scope.
+LAST_SETTLEMENT = {"value": None}
+
+
+def _capture_settlement(func):
+    """Read payment_settlement after @requires_payment has settled.
+
+    Must sit OUTSIDE @requires_payment so it runs after the settle phase.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        result = func(*args, **kwargs)
+        config = kwargs.get("config")
+        if isinstance(config, dict):
+            settlement = config.get("configurable", {}).get("payment_settlement")
+            if settlement is not None:
+                LAST_SETTLEMENT["value"] = settlement
+        return result
+
+    return wrapper
+
+
 @tool
+@_capture_settlement
 @requires_payment(payments=payments, plan_id=NVM_PLAN_ID, credits=1)
 def get_market_insight(topic: str, config: RunnableConfig = None) -> str:
     """Return a short market insight for the requested topic.

--- a/langchain-paid-agent-py/src/buyer.py
+++ b/langchain-paid-agent-py/src/buyer.py
@@ -1,6 +1,7 @@
 """
-Buyer-side: acquire an x402 access token, invoke the agent, print the
-settlement receipt.
+Buyer-side: discover payment requirements from the protocol error,
+acquire an x402 access token against the discovered plan, invoke the
+agent, print the settlement receipt.
 
 Run with: ``poetry run buyer``
 """
@@ -10,6 +11,7 @@ import os
 from dotenv import load_dotenv
 
 from payments_py import Payments, PaymentOptions
+from payments_py.x402.langchain import PaymentRequiredError
 from payments_py.x402.types import DelegationConfig, X402TokenOptions
 
 from .agent import LAST_SETTLEMENT, create_agent
@@ -18,10 +20,6 @@ load_dotenv()
 
 NVM_API_KEY = os.environ["NVM_API_KEY"]
 NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
-NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
-# Provider of the enrolled payment method to use. Must match the provider
-# the plan was created against (the SDK call to Stripe will 404 otherwise).
-PAYMENT_PROVIDER = os.getenv("NVM_PAYMENT_PROVIDER", "stripe")
 
 QUERY = os.getenv("QUERY", "What's the market insight on electric vehicles?")
 
@@ -32,31 +30,45 @@ def main() -> None:
     payments = Payments.get_instance(
         PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
     )
+    agent = create_agent()
 
-    print(f"[1/4] Acquiring x402 access token for plan {NVM_PLAN_ID}...")
-    methods = payments.delegation.list_payment_methods()
-    if not methods:
-        print(
-            "      No payment methods enrolled. Add a card/PayPal at "
-            "https://nevermined.app and re-run."
+    print("[1/5] Asking the agent without paying (discovering requirements)...")
+    try:
+        agent.invoke(
+            {"messages": [("human", QUERY)]},
+            config={"configurable": {}},  # no payment_token
         )
+    except PaymentRequiredError as err:
+        requirements = err.payment_required
+    else:
+        # Defensive: if the agent answered without calling the protected tool
+        # we have nothing to pay for. Bail out instead of hiding the surprise.
+        print("      Unexpected: agent answered without calling the paid tool. Aborting.")
         return
 
-    pm = next((m for m in methods if getattr(m, "provider", None) == PAYMENT_PROVIDER), None)
+    accept = requirements.accepts[0]
+    print(f"      scheme:  {accept.scheme}")
+    print(f"      network: {accept.network}")
+    print(f"      plan_id: {accept.plan_id[:24]}...\n")
+
+    print(f"[2/5] Picking an enrolled payment method matching {accept.network!r}...")
+    methods = payments.delegation.list_payment_methods()
+    pm = next((m for m in methods if getattr(m, "provider", None) == accept.network), None)
     if pm is None:
         available = ", ".join(sorted({getattr(m, "provider", "unknown") for m in methods})) or "<none>"
         print(
-            f"      No {PAYMENT_PROVIDER!r} payment method enrolled. "
-            f"Available providers on this account: {available}. "
-            f"Set NVM_PAYMENT_PROVIDER in .env to match your plan's provider."
+            f"      No {accept.network!r} payment method enrolled. "
+            f"Available on this account: {available}. "
+            f"Enroll a matching method at https://nevermined.app and re-run."
         )
         return
-    print(f"      payment method: {pm.brand} *{pm.last4} (provider: {pm.provider})")
+    print(f"      {pm.brand} *{pm.last4}\n")
 
+    print("[3/5] Acquiring x402 access token from the discovered plan...")
     token_result = payments.x402.get_x402_access_token(
-        NVM_PLAN_ID,
+        accept.plan_id,
         token_options=X402TokenOptions(
-            scheme="nvm:card-delegation",
+            scheme=accept.scheme,
             delegation_config=DelegationConfig(
                 provider_payment_method_id=pm.id,
                 spending_limit_cents=10000,  # $100 cap per delegation
@@ -68,20 +80,15 @@ def main() -> None:
     access_token = token_result["accessToken"]
     print(f"      token = {access_token[:24]}...  (truncated)\n")
 
-    print("[2/4] Building the LangGraph agent...")
-    agent = create_agent()
-    print()
-
-    print(f"[3/4] Invoking the agent with query: {QUERY!r}")
-    configurable = {"payment_token": access_token}
+    print(f"[4/5] Asking the agent again with the token: {QUERY!r}")
     result = agent.invoke(
         {"messages": [("human", QUERY)]},
-        config={"configurable": configurable},
+        config={"configurable": {"payment_token": access_token}},
     )
     final_message = result["messages"][-1]
     print(f"\n      Agent answer: {final_message.content}\n")
 
-    print("[4/4] Settlement receipt:")
+    print("[5/5] Settlement receipt:")
     settlement = LAST_SETTLEMENT["value"]
     if settlement is None:
         print("      (no settlement recorded — the tool may not have been called)")

--- a/langchain-paid-agent-py/src/buyer.py
+++ b/langchain-paid-agent-py/src/buyer.py
@@ -1,0 +1,67 @@
+"""
+Buyer-side: acquire an x402 access token, invoke the agent, print the
+settlement receipt.
+
+Run with: ``poetry run buyer``
+"""
+
+import os
+
+from dotenv import load_dotenv
+
+from payments_py import Payments, PaymentOptions
+
+from .agent import create_agent
+
+load_dotenv()
+
+NVM_SUBSCRIBER_API_KEY = os.environ["NVM_SUBSCRIBER_API_KEY"]
+NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
+NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
+
+QUERY = os.getenv("QUERY", "What's the market insight on electric vehicles?")
+
+
+def main() -> None:
+    buyer_payments = Payments.get_instance(
+        PaymentOptions(nvm_api_key=NVM_SUBSCRIBER_API_KEY, environment=NVM_ENVIRONMENT)
+    )
+
+    print(f"[1/4] Acquiring x402 access token for plan {NVM_PLAN_ID}...")
+    token_result = buyer_payments.x402.get_x402_access_token(NVM_PLAN_ID)
+    access_token = token_result["accessToken"]
+    print(f"      token = {access_token[:24]}...  (truncated)\n")
+
+    print("[2/4] Building the LangGraph agent...")
+    agent = create_agent()
+    print()
+
+    print(f"[3/4] Invoking the agent with query: {QUERY!r}")
+    configurable = {"payment_token": access_token}
+    result = agent.invoke(
+        {"messages": [("human", QUERY)]},
+        config={"configurable": configurable},
+    )
+    final_message = result["messages"][-1]
+    print(f"\n      Agent answer: {final_message.content}\n")
+
+    print("[4/4] Settlement receipt (from configurable.payment_settlement):")
+    settlement = configurable.get("payment_settlement")
+    if settlement is None:
+        print("      (no settlement recorded — the tool may not have been called)")
+        return
+
+    receipt_fields = {
+        "credits_redeemed": getattr(settlement, "credits_redeemed", None),
+        "remaining_balance": getattr(settlement, "remaining_balance", None),
+        "transaction": getattr(settlement, "transaction", None),
+        "network": getattr(settlement, "network", None),
+        "payer": getattr(settlement, "payer", None),
+    }
+    for k, v in receipt_fields.items():
+        if v is not None:
+            print(f"      {k}: {v}")
+
+
+if __name__ == "__main__":
+    main()

--- a/langchain-paid-agent-py/src/buyer.py
+++ b/langchain-paid-agent-py/src/buyer.py
@@ -11,10 +11,10 @@ import os
 from dotenv import load_dotenv
 
 from payments_py import Payments, PaymentOptions
-from payments_py.x402.langchain import PaymentRequiredError
+from payments_py.x402.langchain import PaymentRequiredError, last_settlement
 from payments_py.x402.types import DelegationConfig, X402TokenOptions
 
-from .agent import LAST_SETTLEMENT, create_agent
+from .agent import create_agent
 
 load_dotenv()
 
@@ -22,6 +22,33 @@ NVM_API_KEY = os.environ["NVM_API_KEY"]
 NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
 
 QUERY = os.getenv("QUERY", "What's the market insight on electric vehicles?")
+
+
+def pick_payment_method(payments: Payments, provider: str):
+    """Return the first enrolled payment method whose ``provider`` matches.
+
+    Returns ``None`` and prints an actionable error if no match exists.
+    The error message lists the providers that ARE enrolled on the account
+    so the reader knows what to enroll (or which env var to flip if the
+    plan was created against a different provider).
+
+    A backend-side filter is being requested via nevermined-io/nvm-monorepo#1715
+    — once that lands the SDK can pass ``provider=...`` to ``list_payment_methods``
+    and skip this client-side filter.
+    """
+    methods = payments.delegation.list_payment_methods()
+    pm = next((m for m in methods if getattr(m, "provider", None) == provider), None)
+    if pm is None:
+        available = (
+            ", ".join(sorted({getattr(m, "provider", "unknown") for m in methods}))
+            or "<none>"
+        )
+        print(
+            f"      No {provider!r} payment method enrolled. "
+            f"Available on this account: {available}. "
+            f"Enroll a matching method at https://nevermined.app and re-run."
+        )
+    return pm
 
 
 def main() -> None:
@@ -52,15 +79,8 @@ def main() -> None:
     print(f"      plan_id: {accept.plan_id[:24]}...\n")
 
     print(f"[2/5] Picking an enrolled payment method matching {accept.network!r}...")
-    methods = payments.delegation.list_payment_methods()
-    pm = next((m for m in methods if getattr(m, "provider", None) == accept.network), None)
+    pm = pick_payment_method(payments, accept.network)
     if pm is None:
-        available = ", ".join(sorted({getattr(m, "provider", "unknown") for m in methods})) or "<none>"
-        print(
-            f"      No {accept.network!r} payment method enrolled. "
-            f"Available on this account: {available}. "
-            f"Enroll a matching method at https://nevermined.app and re-run."
-        )
         return
     print(f"      {pm.brand} *{pm.last4}\n")
 
@@ -72,7 +92,7 @@ def main() -> None:
             delegation_config=DelegationConfig(
                 provider_payment_method_id=pm.id,
                 spending_limit_cents=10000,  # $100 cap per delegation
-                duration_secs=604800,        # 1 week TTL
+                duration_secs=3600,          # 1 hour TTL
                 currency="usd",
             ),
         ),
@@ -89,7 +109,7 @@ def main() -> None:
     print(f"\n      Agent answer: {final_message.content}\n")
 
     print("[5/5] Settlement receipt:")
-    settlement = LAST_SETTLEMENT["value"]
+    settlement = last_settlement()
     if settlement is None:
         print("      (no settlement recorded — the tool may not have been called)")
         return

--- a/langchain-paid-agent-py/src/buyer.py
+++ b/langchain-paid-agent-py/src/buyer.py
@@ -10,14 +10,18 @@ import os
 from dotenv import load_dotenv
 
 from payments_py import Payments, PaymentOptions
+from payments_py.x402.types import DelegationConfig, X402TokenOptions
 
-from .agent import create_agent
+from .agent import LAST_SETTLEMENT, create_agent
 
 load_dotenv()
 
 NVM_API_KEY = os.environ["NVM_API_KEY"]
 NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
 NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
+# Provider of the enrolled payment method to use. Must match the provider
+# the plan was created against (the SDK call to Stripe will 404 otherwise).
+PAYMENT_PROVIDER = os.getenv("NVM_PAYMENT_PROVIDER", "stripe")
 
 QUERY = os.getenv("QUERY", "What's the market insight on electric vehicles?")
 
@@ -30,7 +34,37 @@ def main() -> None:
     )
 
     print(f"[1/4] Acquiring x402 access token for plan {NVM_PLAN_ID}...")
-    token_result = payments.x402.get_x402_access_token(NVM_PLAN_ID)
+    methods = payments.delegation.list_payment_methods()
+    if not methods:
+        print(
+            "      No payment methods enrolled. Add a card/PayPal at "
+            "https://nevermined.app and re-run."
+        )
+        return
+
+    pm = next((m for m in methods if getattr(m, "provider", None) == PAYMENT_PROVIDER), None)
+    if pm is None:
+        available = ", ".join(sorted({getattr(m, "provider", "unknown") for m in methods})) or "<none>"
+        print(
+            f"      No {PAYMENT_PROVIDER!r} payment method enrolled. "
+            f"Available providers on this account: {available}. "
+            f"Set NVM_PAYMENT_PROVIDER in .env to match your plan's provider."
+        )
+        return
+    print(f"      payment method: {pm.brand} *{pm.last4} (provider: {pm.provider})")
+
+    token_result = payments.x402.get_x402_access_token(
+        NVM_PLAN_ID,
+        token_options=X402TokenOptions(
+            scheme="nvm:card-delegation",
+            delegation_config=DelegationConfig(
+                provider_payment_method_id=pm.id,
+                spending_limit_cents=10000,  # $100 cap per delegation
+                duration_secs=604800,        # 1 week TTL
+                currency="usd",
+            ),
+        ),
+    )
     access_token = token_result["accessToken"]
     print(f"      token = {access_token[:24]}...  (truncated)\n")
 
@@ -47,8 +81,8 @@ def main() -> None:
     final_message = result["messages"][-1]
     print(f"\n      Agent answer: {final_message.content}\n")
 
-    print("[4/4] Settlement receipt (from configurable.payment_settlement):")
-    settlement = configurable.get("payment_settlement")
+    print("[4/4] Settlement receipt:")
+    settlement = LAST_SETTLEMENT["value"]
     if settlement is None:
         print("      (no settlement recorded — the tool may not have been called)")
         return

--- a/langchain-paid-agent-py/src/buyer.py
+++ b/langchain-paid-agent-py/src/buyer.py
@@ -15,7 +15,7 @@ from .agent import create_agent
 
 load_dotenv()
 
-NVM_SUBSCRIBER_API_KEY = os.environ["NVM_SUBSCRIBER_API_KEY"]
+NVM_API_KEY = os.environ["NVM_API_KEY"]
 NVM_ENVIRONMENT = os.getenv("NVM_ENVIRONMENT", "sandbox")
 NVM_PLAN_ID = os.environ["NVM_PLAN_ID"]
 
@@ -23,12 +23,14 @@ QUERY = os.getenv("QUERY", "What's the market insight on electric vehicles?")
 
 
 def main() -> None:
-    buyer_payments = Payments.get_instance(
-        PaymentOptions(nvm_api_key=NVM_SUBSCRIBER_API_KEY, environment=NVM_ENVIRONMENT)
+    # The buyer uses the same Nevermined account as the seller in this demo;
+    # the account has subscribed to its own plan to acquire x402 tokens.
+    payments = Payments.get_instance(
+        PaymentOptions(nvm_api_key=NVM_API_KEY, environment=NVM_ENVIRONMENT)
     )
 
     print(f"[1/4] Acquiring x402 access token for plan {NVM_PLAN_ID}...")
-    token_result = buyer_payments.x402.get_x402_access_token(NVM_PLAN_ID)
+    token_result = payments.x402.get_x402_access_token(NVM_PLAN_ID)
     access_token = token_result["accessToken"]
     print(f"      token = {access_token[:24]}...  (truncated)\n")
 


### PR DESCRIPTION
## Summary

- Adds `tutorials/langchain-paid-agent-py/`: a deliberately minimal LangChain + Nevermined integration tutorial — one payment-protected `@tool`, one buyer script, one LangGraph ReAct agent.
- Demonstrates the `@requires_payment` decorator and the x402 token-via-`RunnableConfig.configurable` flow with no HTTP layer and no 402 round-trip.
- The seller and buyer run in-process so the payment flow (acquire token → invoke → verify → settle → read receipt) is the only signal in the demo.
- Lists the tutorial in the top-level `README.md` and `CLAUDE.md`.

Part of the LangChain integration deepening epic at nevermined-io/nvm-monorepo#1703, Sprint 0 sub-issue nevermined-io/nvm-monorepo#1704.

## Test plan

- [x] `poetry install` resolves cleanly (`payments-py 1.6.0`, `langgraph 0.6.11`, `langchain-openai 0.3.35`).
- [x] `python -m py_compile src/agent.py src/buyer.py` passes.
- [x] All Nevermined + LangChain imports resolve at runtime.
- [x] `SettleResponse` attribute names (`credits_redeemed`, `remaining_balance`, `transaction`, `network`, `payer`) verified against the actual SDK type.
- [ ] **End-to-end run against the Nevermined sandbox** with a real builder + subscriber API key and a real plan ID — prints all four payment-flow steps and a settlement receipt.
- [ ] ~2 min demo recording attached to nvm-monorepo#1704.
- [ ] Docs link added in `docs/integrate/add-to-your-agent/langchain.mdx` (the final step of Sprint 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)