### PR TITLE
docs: retire docs.nevermined.app in favour of nevermined.ai/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ For development and testing, use Stripe's test card:
 
 ## Documentation
 
-- [Nevermined Documentation](https://docs.nevermined.app)
+- [Nevermined Documentation](https://nevermined.ai/docs)
 - [A2A Protocol Specification](https://a2aproject.github.io/A2A/latest)
 - [Model Context Protocol (MCP)](https://modelcontextprotocol.io)
 - [Nevermined Payments SDK](https://github.com/nevermined-io/payments)

--- a/a2a-examples/a2a-agent-client-example/README.md
+++ b/a2a-examples/a2a-agent-client-example/README.md
@@ -212,6 +212,6 @@ node dist/client.js
 ---
 
 ## Further Reading
-- [Nevermined Documentation](https://docs.nevermined.app)
+- [Nevermined Documentation](https://nevermined.ai/docs)
 - [A2A Protocol Specification](https://a2aproject.github.io/A2A/latest)
 - [GitHub Repository](https://github.com/nevermined-io/payments) 

--- a/async-logger/README.md
+++ b/async-logger/README.md
@@ -129,6 +129,6 @@ Please refer to the **[financial-agent tutorial](../financial-agent)**, which pr
 
 ## Learn More
 
-- [Nevermined Payments SDK Documentation](https://docs.nevermined.app)
-- [Observability Guide](https://docs.nevermined.app/docs/development-guide/observability)
+- [Nevermined Payments SDK Documentation](https://nevermined.ai/docs)
+- [Observability Guide](https://nevermined.ai/docs/development-guide/observability)
 - [Financial Agent Tutorial](../financial-agent) - Full agent example

--- a/pricing-simulation-py/README.md
+++ b/pricing-simulation-py/README.md
@@ -193,6 +193,6 @@ Once you're ready for production, transition to the full agent implementation wi
 
 ## Learn More
 
-- [Nevermined Payments SDK Documentation](https://docs.nevermined.app)
-- [Observability Guide](https://docs.nevermined.app/docs/development-guide/observability)
+- [Nevermined Payments SDK Documentation](https://nevermined.ai/docs)
+- [Observability Guide](https://nevermined.ai/docs/development-guide/observability)
 - [Python SDK GitHub Repository](https://github.com/nevermined-io/payments-py)

--- a/pricing-simulation/README.md
+++ b/pricing-simulation/README.md
@@ -164,6 +164,6 @@ Once you're ready for production, transition to the full agent implementation wi
 
 ## Learn More
 
-- [Nevermined Payments SDK Documentation](https://docs.nevermined.app)
-- [Observability Guide](https://docs.nevermined.app/docs/development-guide/observability)
+- [Nevermined Payments SDK Documentation](https://nevermined.ai/docs)
+- [Observability Guide](https://nevermined.ai/docs/development-guide/observability)
 - [Financial Agent Tutorial](../financial-agent) - Full production agent example


### PR DESCRIPTION
## What

Replaces the 8 remaining `docs.nevermined.app` references in this repo with their `nevermined.ai/docs` equivalents.

| File | Mentions |
| --- | --- |
| `README.md` | 1 |
| `a2a-examples/a2a-agent-client-example/README.md` | 1 |
| `async-logger/README.md` | 2 |
| `pricing-simulation/README.md` | 2 |
| `pricing-simulation-py/README.md` | 2 |

## Mapping

Not a blind host substitution — the redirect strips the extra `/docs` path segment:

- `https://docs.nevermined.app` → `https://nevermined.ai/docs`
- `https://docs.nevermined.app/docs/development-guide/observability` → `https://nevermined.ai/docs/development-guide/observability` (verified `200`)

A naive host-only rewrite would have produced `nevermined.ai/docs/docs/development-guide/observability`, which is a `404`.

## Notes

- Matches the convention already used in `http-simple-agent-ts/README.md` and `http-simple-agent-py/README.md`, which link to `nevermined.ai/docs` today.
- No `docs-analytics.js`, no dead `api-reference/versioning` links, and no occurrences of the host as visible link text in this repo — the three cases the tracking issue flags as needing manual care do not apply here.
- Docs-only change; no code touched.

Refs nevermined-io/nevermined.ai-website#233

🤖 Generated with [Claude Code](https://claude.com/claude-code)